### PR TITLE
6 Make login responsive to mobile dimensions

### DIFF
--- a/react-app/src/pages/LoginPage/LoginPage.module.css
+++ b/react-app/src/pages/LoginPage/LoginPage.module.css
@@ -10,13 +10,15 @@
 /* left image panel */
 .left {
     left: 0;
-    width:65%
+    width: 65%;
+    max-width: calc(100vw - 600px);
 }
 
 /* right login panel */
 .right {
     right: 0;
-    width: 35%
+    width: 35%;
+    min-width: 600px;
 }
 
 /* center right login panel vertically & horizontally */
@@ -99,9 +101,10 @@
 /* mobile */
 @media (max-width: 600px) {
     .left {
-        width: 0%
+        width: 0%;
     }
     .right {
-        width: 100%
+        width: 100%;
+        min-width: 0%;
     }
 }

--- a/react-app/src/pages/LoginPage/LoginPage.module.css
+++ b/react-app/src/pages/LoginPage/LoginPage.module.css
@@ -59,6 +59,7 @@
     color: var(--blue-gray);
 }
 
+/* switch to admin login - style to look like link */
 .switch{
     font-weight: bold;
     text-decoration: underline;
@@ -69,6 +70,7 @@
     margin: 8% 0% 5% 0%
 }
 
+/* for left panel */
 .leftImgContainer {
     width: 100%;
     height: 100%;
@@ -81,6 +83,7 @@
     object-fit: cover;
 }
 
+/* for logo */
 .rightImgContainer {
     width: 43%;
     height: 43%;

--- a/react-app/src/pages/LoginPage/LoginPage.module.css
+++ b/react-app/src/pages/LoginPage/LoginPage.module.css
@@ -82,3 +82,13 @@
     height: 100%;
     object-fit: cover;
 }
+
+/* mobile */
+@media (max-width: 600px) {
+    .left {
+        width: 0%
+    }
+    .right {
+        width: 100%
+    }
+}

--- a/react-app/src/pages/LoginPage/LoginPage.module.css
+++ b/react-app/src/pages/LoginPage/LoginPage.module.css
@@ -59,6 +59,16 @@
     color: var(--blue-gray);
 }
 
+.switch{
+    font-weight: bold;
+    text-decoration: underline;
+    text-underline-position: under;
+    background-color: white;
+    border: none;
+    cursor: pointer;
+    margin: 8% 0% 5% 0%
+}
+
 .leftImgContainer {
     width: 100%;
     height: 100%;

--- a/react-app/src/pages/LoginPage/LoginPage.tsx
+++ b/react-app/src/pages/LoginPage/LoginPage.tsx
@@ -141,6 +141,11 @@ function LoginPage() {
             >
               Continue as guest
             </Button>
+
+            {/* switch to admin link */}
+            <button className={styles.switch}>
+                Switch to Admin Log In
+            </button>
           </div>
         </div>
       </div>

--- a/react-app/src/pages/LoginPage/LoginPage.tsx
+++ b/react-app/src/pages/LoginPage/LoginPage.tsx
@@ -12,18 +12,30 @@ import { Visibility, VisibilityOff } from "@mui/icons-material";
 import styles from "./LoginPage.module.css";
 import primaryLogo from "../../assets/atc-primary-logo.png";
 
-const styledSignInButton = {
-  backgroundColor: "var(--ocean-green)",
-  border: "2px solid var(--ocean-green)",
+const styledRectButton = {
   borderRadius: "0px",
   boxShadow: "none",
   width: 350,
   marginTop: "5%",
   padding: "2%",
+};
+
+const styledSignIn = {
+  backgroundColor: "var(--ocean-green)",
+  border: "2px solid var(--ocean-green)",
   "&:hover": {
     backgroundColor: "var(--ocean-green)",
   },
-};
+}
+
+const styledContinueAsGuest = {
+  color: "var(--ocean-green)",
+  backgroundColor: "white",
+  border: "2px solid var(--ocean-green)",
+  "&:hover": {
+    backgroundColor: "white",
+  },
+}
 
 const styledInputBoxes = {
   border: "1px solid black",
@@ -114,11 +126,20 @@ function LoginPage() {
 
             {/* sign in button */}
             <Button
-              sx={styledSignInButton}
+              sx={{ ...styledRectButton, ...styledSignIn }}
               variant="contained"
               href="#contained-buttons"
             >
               Sign in
+            </Button>
+
+            {/* continue as guest button */}
+            <Button
+              sx={{ ...styledRectButton, ...styledContinueAsGuest }}
+              variant="contained"
+              href="#contained-buttons"
+            >
+              Continue as guest
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Remove left image panel for a screen with max-width: 600px

Add Continue as Guest button and Switch to Admin Login button
- styling for the rectangle buttons was in tsx file, so I kept it there
- added styling for Switch button in css file

full screen:
<img width="1512" alt="Screenshot 2024-02-25 at 5 01 00 PM" src="https://github.com/Hack4Impact-UMD/appalachian-trail-conservancy/assets/69590854/9105b028-349b-4f31-9e6d-d01747ede3ca">

mid width screen:
<img width="949" alt="Screenshot 2024-02-25 at 5 01 19 PM" src="https://github.com/Hack4Impact-UMD/appalachian-trail-conservancy/assets/69590854/b2077934-2362-41c6-8ae5-da00302bb091">

mobile screen:
<img width="704" alt="Screenshot 2024-02-25 at 5 01 27 PM" src="https://github.com/Hack4Impact-UMD/appalachian-trail-conservancy/assets/69590854/f8604c66-2ed3-4a8f-9fe5-37c640747015">
